### PR TITLE
Catch up; moved to HassIO; added HADashboard and bus sensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ ip_bans.yaml
 nest.conf
 usps_cache.sqlite
 .cloud/
+.google_maps_location_sharing.cookies
+appdaemon/appdaemon.yaml
+entity_registry.yaml

--- a/appdaemon/dashboards/wall_display.dash
+++ b/appdaemon/dashboards/wall_display.dash
@@ -1,0 +1,141 @@
+#
+# Main arguments, all optional
+#
+title: Wall Display
+# widget_dimensions: [120, 120]
+widget_dimensions: [154, 154]
+widget_margins: [5, 5]
+
+scalable: False # Disable tap to zoon
+columns: 8
+# rows: 5
+
+global_parameters:
+  use_hass_icon: 1
+  widget_style: "font-size: 128%;"
+  level_up_style: "font-size: 140%;"
+  level_down_style: "font-size: 140%;"
+
+corban_presence:
+  widget_type: device_tracker
+  title: Corban
+  device: edith_wifi
+  enable: 1
+
+maggie_presence:
+  widget_type: device_tracker
+  title: Maggie
+  device: jackie_wifi
+  enable: 1
+
+corban_maps_presence:
+  widget_type: device_tracker
+  title: Corban
+  device: google_maps_110168280884137709870
+  icon_on: fa-male
+  # enable: 1
+
+maggie_maps_presence:
+  widget_type: device_tracker
+  title: Maggie
+  device: google_maps_106112096418399445974
+  icon_on: fa-female
+  # enable: 1
+
+clock:
+  widget_type: clock
+  date_format_country: "us"
+  date_format_options:
+    weekday: "short"
+    year: "numeric"
+    month: "short"
+    day: "numeric"
+  date_style: "font-size: 128%;"
+  time_style: "color: #ffaa00;"
+
+weather_custom:
+  widget_type: weather
+  # title: Today
+  units: "°F"
+  prefer_icons: 1
+  # show_forecast: 1
+  forecast_title: Tomorrow
+
+bus_time:
+  widget_type: sensor
+  title: Next Bus
+  units: ""
+  precision: 1
+  entity: sensor.bus_1_time
+  sub_entity: sensor.bus_2_time
+
+reload:
+  widget_type: reload
+  title: Reload
+
+living_room_media_player:
+  title: Living Room
+  widget_type: media_player
+  entity: media_player.living_room
+
+spotify:
+  title: Spotify
+  widget_type: media_player
+  entity: media_player.spotify
+
+everything_off:
+  widget_type: script
+  entity: script.everything_off
+  title: Everything Off
+  icon_off: mdi-power
+  icon_on: mdi-timer-sand
+
+living_room_temp:
+  widget_type: climate
+  entity: climate.living_room
+  title: Living Room
+  title2: Temperature
+
+living_room_humidity:
+  widget_type: gauge
+  entity: sensor.living_room_thermostat_humidity
+  max: "100"
+  min: "0"
+  units: "%"
+  title: Living Room
+  title2: Humidity
+
+bedroom_temp:
+  widget_type: sensor
+  entity: sensor.bedroom_temperature
+  title: Bedroom
+  title2: Temperature
+
+bedroom_humidity:
+  widget_type: gauge
+  entity: sensor.bedroom_humidity
+  max: "100"
+  min: "0"
+  units: "%"
+  title: Bedroom
+  title2: Humidity
+
+living_room_lights:
+  widget_type: group
+  entity: group.living_room_lights
+  monitored_entity: light.living_room_tv_backlight
+  title: Living Room Lights
+
+bus_alert_toggle:
+  widget_type: input_boolean
+  entity: input_boolean.bus_alert
+  title: Bus Alert
+  # icon_on: mdi-bus
+  # icon_off: mdi-bus
+
+layout:
+    - clock(2x1), weather_custom(4x1), bus_time, reload
+    - corban_presence, maggie_presence, living_room_temp, bedroom_temp, spotify(2x2), living_room_media_player(2x2)
+    - corban_maps_presence, maggie_maps_presence, living_room_humidity, bedroom_humidity
+    -
+    - light.fairy_lights, living_room_lights, spacer, scene.movie_mode, spacer(1x1), bus_alert_toggle, spacer, everything_off

--- a/cloud_alexa.yaml
+++ b/cloud_alexa.yaml
@@ -1,0 +1,48 @@
+filter:
+  include_entities:
+    - group.living_room_lights
+    - group.bedroom_lights
+    - group.all_lights_custom
+    - light.living_room_tv_backlight
+    - light.fairy_lights
+    - media_player.living_room
+    - scene.movie_mode
+    - switch.living_room_window
+    - switch.living_room_corner
+    - switch.living_room_lamp_near_tv
+    - switch.living_room_couch
+    - switch.strobe_light
+    - script.everything_off
+    - light.exit_sign
+    # - script.play_pause_master # Test this vs the media player
+    - script.move_spotify_to_bedroom_echo
+    - input_boolean.party_mode
+    - input_boolean.scary_mode
+    - switch.obama
+    - light.wall_display_light
+    - light.wall_display_screen
+
+entity_config:
+  group.all_lights_custom:
+    name: All Lights
+    # display_categories: LIGHT
+  light.living_room_tv_backlight:
+    name: Back light
+  media_player.living_room:
+    name: TV
+  switch.living_room_window:
+    display_categories: LIGHT
+  switch.living_room_corner:
+    display_categories: LIGHT
+  switch.living_room_lamp_near_tv:
+    display_categories: LIGHT
+  switch.living_room_couch:
+    display_categories: LIGHT
+  switch.strobe_light:
+    display_categories: LIGHT
+  # script.play_pause_master:
+  #   name: T.V. Show
+  script.move_spotify_to_bedroom_echo:
+    name: "Move music to the bedroom"
+  switch.obama:
+    name: Server

--- a/cloud_google.yaml
+++ b/cloud_google.yaml
@@ -1,0 +1,35 @@
+filter:
+  include_entities:
+    - group.living_room_lights
+    - group.bedroom_lights
+    - group.all_lights_custom
+    - light.living_room_tv_backlight
+    - light.fairy_lights
+    - media_player.living_room
+    - scene.movie_mode
+    - switch.living_room_window
+    - switch.living_room_corner
+    - switch.living_room_lamp_near_tv
+    - switch.living_room_couch
+    - switch.strobe_light
+    - script.everything_off
+    - light.exit_sign
+    # - script.play_pause_master # Test this vs the media player
+    - script.move_spotify_to_bedroom_echo
+    - input_boolean.party_mode
+    - input_boolean.scary_mode
+    - switch.obama
+
+entity_config:
+  group.all_lights_custom:
+    name: All Lights
+  light.living_room_tv_backlight:
+    name: Back light
+  media_player.living_room:
+    name: TV
+  # script.play_pause_master:
+  #   name: T.V. Show
+  script.move_spotify_to_bedroom_echo:
+    name: "Move music to the bedroom"
+  switch.obama:
+    name: Server

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -22,38 +22,15 @@ updater:
   include_used_components: true
 
 # Trying out the HASS Cloud
-# cloud:
-#   alexa:
-#     filter:
-#       include_entities:
-#         - group.living_room_lights
-#       # include_domains:
-#       #   - switch
-#       #   - light
-#       # exclude_entities:
-#       #   - switch.outside
-#       exclude_domains:
-#         - alert
-#         - automation
-#         - cover
-#         - fan
-#         - group
-#         - input_boolean
-#         # - light
-#         - lock
-#         - media_player # (play, pause, stop, set volume, adjust volume, next track, and previous track)
-#         - scene
-#         - script
-#         - switch
-#     entity_config:
-#       group.living_room_lights:
-#         name: Living Room Lights
-#         description: The lights in the living room.
-#         display_categories: LIGHT
+cloud:
+  alexa: !include cloud_alexa.yaml
+  google_actions: !include cloud_google.yaml
+
 config:
 
+hassio:
+
 recorder:
-  db_url: !secret mysql_db_connection
   purge_interval: 2
   purge_keep_days: 60
   exclude:
@@ -67,6 +44,7 @@ recorder:
     entities:
       - sun.sun   # Don't record sun data
       - sensor.yi_most_recent_recording # It changes each minute
+      - sensor.time
 
 # Enables support for tracking state changes over time.
 history:
@@ -81,6 +59,7 @@ history:
     entities:
       - sun.sun   # Don't record sun data
       - sensor.yi_most_recent_recording # It changes each minute
+      - sensor.time
 
 history_graph:
   temperatures:
@@ -201,9 +180,7 @@ logger:
     # homeassistant.components.device_tracker: critical
 
 mqtt:
-  broker: 127.0.0.1
-  # port: 1883
-  # client_id: home-assistant-1
+  broker: core-mosquitto # Addon
   username: !secret mqtt_username
   password: !secret mqtt_password
 
@@ -212,9 +189,14 @@ device_tracker:
     devices:
       edith_wifi: /devices/location/edith_wifi
       jackie_wifi: /devices/location/jackie_wifi
+  - platform: google_maps
+    username: !secret google_maps_username
+    password: !secret google_maps_password
   # - platform: bluetooth_tracker
   #   track_new_devices: False
   #   consider_home: 60
+
+map:
 
 # usps:
 #   username: !secret usps_username
@@ -260,9 +242,9 @@ google:
 tts:
   - platform: google
 
-emulated_hue:
-  host_ip: !secret hass_ip_address
-  expose_by_default: false
+# emulated_hue:
+#   host_ip: !secret hass_ip_address
+#   expose_by_default: false
 
 automation: !include_dir_merge_list automation
 group: !include_dir_merge_named group

--- a/custom_components/light/walldisplay.py
+++ b/custom_components/light/walldisplay.py
@@ -1,0 +1,170 @@
+# This custom component allows the control of a Philips digital signage display.
+# https://www.usa.philips.com/c-p/10BDL3051T_00/signage-solutions-multi-touch-display
+# It uses the SICP protocol:
+# https://www.keren.nl/dynamic/media/1/documents/Drivers/The%20SICP%20Commands%20Document%20V1_99%2025%20May2017.pdf
+#
+# This component exposes two new lights:
+# - Wall Display Light: The RGB LEDs on the side of the display.
+# - Wall Display Screen: The screen itself. This should probably be a switch component, but oh well.
+
+import logging
+
+import voluptuous as vol
+import socket # This should probably be inside something below.
+
+# Import the device class from the component that you want to support
+from homeassistant.components.light import SUPPORT_COLOR, Light, PLATFORM_SCHEMA, ATTR_HS_COLOR
+from homeassistant.const import CONF_HOST
+import homeassistant.helpers.config_validation as cv
+import homeassistant.util.color as color_util
+
+_LOGGER = logging.getLogger(__name__)
+
+# Validation of the user's configuration
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string
+})
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+
+    # Assign configuration variables. The configuration check takes care they are
+    # present.
+    host = config.get(CONF_HOST)
+
+    helper = WallDisplayHelper(host)
+
+    # Add devices
+    add_devices([WallDisplayLight(helper), WallDisplayBacklight(helper)])
+
+class WallDisplayHelper:
+    def __init__(self, host):
+        self._host = host
+        self._port = 5000
+
+    # Turn off the display
+    def sleep(self):
+        self._send_data(b'\x18\x01')
+
+    # Turn on the display
+    def wake(self):
+        self._send_data(b'\x18\x02')
+
+    # Set the side LEDs to the given color.
+    # Range for each: 0 - 255
+    def set_color(self, r, g, b):
+        ba = bytearray(b'\xF3\x01')
+        ba.append(r)
+        ba.append(g)
+        ba.append(b)
+        self._send_data(ba)
+
+    # Helper to actually send the data.
+    def _send_data(self, ba):
+        size = len(ba) + 4 # 4 other standard bytes
+        ba1 = bytearray()
+        ba1.append(size)
+        ba1.append(0x01)
+        ba1.append(0x00)
+        ba1.extend(ba)
+        check = 0
+        for i in ba1:
+            check = check ^ i
+        ba1.append(check)
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect((self._host, self._port))
+        s.send(ba1)
+        # print(s.recv(2048)) # Debug printout
+        s.close()
+
+class WallDisplayLight(Light):
+    def __init__(self, helper):
+        self._helper = helper
+        self._name = "Wall Display Light"
+        self._state = False
+        self._color = [0, 0] # White
+
+        self._supported_features = SUPPORT_COLOR
+
+    @property
+    def name(self):
+        """Return the display name of this light."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if light is on."""
+        return self._state
+
+    def turn_on(self, **kwargs):
+        """Turn on a LED."""
+        if ATTR_HS_COLOR in kwargs:
+            self._color = kwargs[ATTR_HS_COLOR]
+
+        self._helper.set_color(*color_util.color_hs_to_RGB(*self._color))
+
+        self._state = True
+        self.schedule_update_ha_state()
+
+
+    def turn_off(self, **kwargs):
+        """Instruct the light to turn off."""
+        self._helper.set_color(0, 0, 0)
+        self._state = False
+        self.schedule_update_ha_state()
+
+    @property
+    def assumed_state(self):
+        """Return true if we do optimistic updates."""
+        return True
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return self._supported_features
+
+    @property
+    def should_poll(self):
+        return False
+
+    @property
+    def hs_color(self):
+        """Return the color property."""
+        return self._color
+
+class WallDisplayBacklight(Light):
+    def __init__(self, helper):
+        self._helper = helper
+        self._name = "Wall Display Screen"
+        self._state = True # Default to on
+
+    @property
+    def name(self):
+        """Return the display name of this light."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if light is on."""
+        return self._state
+
+    def turn_on(self, **kwargs):
+        self._helper.wake()
+
+        self._state = True
+        self.schedule_update_ha_state()
+
+
+    def turn_off(self, **kwargs):
+        """Instruct the light to turn off."""
+        self._helper.sleep()
+        self._state = False
+        self.schedule_update_ha_state()
+
+    @property
+    def assumed_state(self):
+        """Return true if we do optimistic updates."""
+        return True
+
+    @property
+    def should_poll(self):
+        return False

--- a/customize/scenes.yaml
+++ b/customize/scenes.yaml
@@ -3,6 +3,7 @@
 scene.movie_mode:
   hidden: true
   emulated_hue_hidden: false
+  icon: mdi:movie
 
 # TV backlight scenes
 scene.tv_bright:

--- a/group/all_lights.yaml
+++ b/group/all_lights.yaml
@@ -10,6 +10,8 @@ all_lights_custom:
     - light.fairy_lights
     - switch.living_room_window
     - switch.living_room_couch
+    - light.wall_display_light
+    # - input_boolean.bus_alert # Because it will just keep turning the light back on.
 
 # All lights, switches, and media_player, for Alexa
 everything_custom:
@@ -25,3 +27,6 @@ everything_custom:
     - media_player.kodi_obama
     - media_player.corban_and_maggie
     - switch.strobe_light
+    - light.wall_display_screen
+    - light.wall_display_light
+    # - input_boolean.bus_alert # Because it will just keep turning the light back on.

--- a/group/default_view.yaml
+++ b/group/default_view.yaml
@@ -3,11 +3,13 @@
 default_view:
   view: yes
   name: !secret home_name
+  icon: mdi:home
   entities:
     - updater.updater
+    - device_tracker.google_maps_110168280884137709870 # Corban
+    - device_tracker.google_maps_106112096418399445974 # Maggie
     - device_tracker.edith_wifi
     - device_tracker.jackie_wifi
-    # - group.obama_download_display # Only shown when downloads are waiting
     - group.living_room_lights
     - group.bedroom_lights
     - group.guest_items
@@ -18,8 +20,10 @@ default_view:
 #   entities:
 #     - switch.coffee_maker
 
-# devices:
-#   name: Device Trackers
-#   entities:
-#     - device_tracker.edith_wifi
-#     - device_tracker.jackie_wifi
+devices:
+  name: Device Trackers
+  entities:
+    - device_tracker.google_maps_110168280884137709870 # Corban
+    - device_tracker.google_maps_106112096418399445974 # Maggie
+    - device_tracker.edith_wifi
+    - device_tracker.jackie_wifi

--- a/group/management.yaml
+++ b/group/management.yaml
@@ -10,12 +10,12 @@ view_management:
     - group.obama_management_scripts
     - group.hass_notifications # See packages/home_assistant_notifications.yaml
     - group.hass_utilities  # See packages/hass_utilities
-    - group.temperature_brightness  # See packages/backlight_temperature
+    - group.temperature_backlight  # See packages/backlight_temperature
     - group.dash_button_1
     - group.testing_scripts
     - group.octoprint
     - media_player.spotify
-
+    - group.bus_times
 
 obama_management_scripts:
   name: Obama Management
@@ -25,10 +25,9 @@ obama_management_scripts:
     - script.shutdown_obama
     - switch.obama
 
-
 testing_scripts:
   name: Test Scripts
   entities:
     - automation.bedside_button
     - script.play_pause_master
-    - light.test_light
+    # - light.test_light

--- a/light/mqtt_json.yaml
+++ b/light/mqtt_json.yaml
@@ -20,16 +20,16 @@
   retain: true
   qos: 0
 
-- platform: mqtt_json
-  name: test_light
-  state_topic: "home/test_light"
-  command_topic: "home/test_light/set"
-  brightness: true
-  rgb: true
-  white_value: true
-  color_temp: true
-  effect: true
-  effect_list: [colorfade_slow, colorfade_fast, flash]
-  optimistic: false
-  retain: true
-  qos: 0
+# - platform: mqtt_json
+#   name: test_light
+#   state_topic: "home/test_light"
+#   command_topic: "home/test_light/set"
+#   brightness: true
+#   rgb: true
+#   white_value: true
+#   color_temp: true
+#   effect: true
+#   effect_list: [colorfade_slow, colorfade_fast, flash]
+#   optimistic: false
+#   retain: true
+#   qos: 0

--- a/packages/backlight_temperature.yaml
+++ b/packages/backlight_temperature.yaml
@@ -114,8 +114,8 @@ homeassistant:
 
 
 group:
-  temperature_brightness:
-    name: "Temperature-Controlled Brightness"
+  temperature_backlight:
+    name: "Temperature-Controlled Backlight"
     control: hidden
     entities:
       - automation.set_tv_backlight_based_on_temperature

--- a/packages/party_mode.yaml
+++ b/packages/party_mode.yaml
@@ -158,4 +158,3 @@ homeassistant:
   customize:
     input_boolean.party_mode:
       emulated_hue_hidden: false
-      emulated_hue_name: "Party mode"

--- a/packages/scary_mode.yaml
+++ b/packages/scary_mode.yaml
@@ -117,4 +117,3 @@ homeassistant:
   customize:
     input_boolean.scary_mode:
       emulated_hue_hidden: false
-      emulated_hue_name: "Scary mode"

--- a/packages/transit.yaml
+++ b/packages/transit.yaml
@@ -1,0 +1,228 @@
+light:
+  - platform: walldisplay
+    host: !secret wall_display_ip
+
+sensor:
+  - platform: rest
+    name: Busses at Stop
+    scan_interval: 30
+    force_update: true
+    resource: !secret transit_api_url
+    json_attributes:
+      - data
+    value_template: >-
+      {% if states.sensor.busses_at_stop.attributes["data"] | length > 0 %}
+        {{ as_timestamp(value_json["data"][0]["attributes"]["arrival_time"]) | timestamp_custom("%I:%M %p") }}
+      {% else %}
+        N/A
+      {% endif %}
+    headers:
+      x-api-key: !secret transit_api_key
+  - platform: template
+    sensors:
+      bus_1_time:
+        friendly_name: 'Bus 1 - Time'
+        unit_of_measurement: Minutes
+        value_template: >-
+          {% if states.sensor.busses_at_stop.attributes["data"] | length > 0 %}
+            {{ ((as_timestamp(states.sensor.busses_at_stop.attributes["data"][0]["attributes"]["arrival_time"]) - as_timestamp(now())) / 60) | round(1) }}
+          {% else %}
+            N/A
+          {% endif %}
+      bus_1_route:
+        friendly_name: 'Bus 1 - Route'
+        value_template: >-
+          {% if states.sensor.busses_at_stop.attributes["data"] | length > 0 %}
+            {{ states.sensor.busses_at_stop.attributes["data"][0]["relationships"]["route"]["data"]["id"] }}
+          {% else %}
+            N/A
+          {% endif %}
+      bus_2_time:
+        friendly_name: 'Bus 2 - Time'
+        unit_of_measurement: Minutes
+        value_template: >-
+          {% if states.sensor.busses_at_stop.attributes["data"] | length > 1 %}
+            {{ ((as_timestamp(states.sensor.busses_at_stop.attributes["data"][1]["attributes"]["arrival_time"]) - as_timestamp(now())) / 60) | round(1) }}
+          {% else %}
+            N/A
+          {% endif %}
+      bus_2_route:
+        friendly_name: 'Bus 2 - Route'
+        value_template: >-
+          {% if states.sensor.busses_at_stop.attributes["data"] | length > 1 %}
+            {{ states.sensor.busses_at_stop.attributes["data"][1]["relationships"]["route"]["data"]["id"] }}
+          {% else %}
+            N/A
+          {% endif %}
+
+input_boolean:
+  bus_alert:
+    name: Bus Alert
+    initial: on
+    icon: mdi:bus
+    # icon: mdi:bus-clock
+  bus_alert_active:
+    name: Bus Alert Active
+    initial: off
+    icon: mdi:calendar-range
+
+binary_sensor:
+  - platform: workday
+    name: Corban Office Workdays
+    country: US
+    workdays: [mon, tue, wed, thu]
+
+automation:
+  # SCREEN
+  - alias: Turn on the wall display when Corban gets home
+    trigger:
+      - platform: state
+        entity_id: device_tracker.edith_wifi
+        # from: "not_home"
+        to: "home"
+    action:
+      - service: light.turn_on
+        data:
+          entity_id: light.wall_display_screen
+
+  - alias: Turn on the wall display in the morning # if Corban is home
+    trigger:
+      - platform: time
+        at: '06:30:00'
+    condition:
+      - condition: state
+        entity_id: device_tracker.edith_wifi
+        state: "home"
+    action:
+      - service: light.turn_on
+        data:
+          entity_id: light.wall_display_screen
+
+  # BUS ALERT
+
+  # Enable at 6:30 AM on workdays
+  - alias: Enable the bus alert based on time
+    trigger:
+      - platform: time
+        at: '06:30:00'
+    condition:
+      - condition: state
+        entity_id: binary_sensor.corban_office_workdays
+        state: 'on'
+    action:
+      - service: input_boolean.turn_on
+        data:
+          entity_id: input_boolean.bus_alert_active
+  - alias: Disable the bus alert based on time
+    trigger:
+      - platform: time
+        at: '09:00:00' # Disable at 9AM
+    action:
+      - service: input_boolean.turn_off
+        data:
+          entity_id: input_boolean.bus_alert_active
+
+  - alias: "Turn off the wall display light when the automations are disabled"
+    trigger:
+      - platform: state
+        entity_id: input_boolean.bus_alert
+        to: "off"
+      - platform: state
+        entity_id: input_boolean.bus_alert_active
+        to: "off"
+    action:
+      - service: light.turn_off
+        data:
+          entity_id: light.wall_display_light
+
+  - alias: "Set display LED based on bus time - 1"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.bus_1_time
+        # above: 1
+        below: 2
+    condition:
+      - condition: state
+        entity_id: input_boolean.bus_alert
+        state: "on"
+      - condition: state
+        entity_id: input_boolean.bus_alert_active
+        state: "on"
+    action:
+      - service: light.turn_on
+        data:
+          entity_id: light.wall_display_light
+          rgb_color: [255, 0, 0]
+  - alias: "Set display LED based on bus time - 2"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.bus_1_time
+        above: 1.9 # >= 2
+        below: 10
+    condition:
+      - condition: state
+        entity_id: input_boolean.bus_alert
+        state: "on"
+      - condition: state
+        entity_id: input_boolean.bus_alert_active
+        state: "on"
+    action:
+      - service: light.turn_on
+        data:
+          entity_id: light.wall_display_light
+          rgb_color: [0, 255, 0]
+  - alias: "Set display LED based on bus time - 3"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.bus_1_time
+        above: 9.9 # >= 10
+        # below: 10
+    condition:
+      - condition: state
+        entity_id: input_boolean.bus_alert
+        state: "on"
+      - condition: state
+        entity_id: input_boolean.bus_alert_active
+        state: "on"
+    action:
+      - service: light.turn_on
+        data:
+          entity_id: light.wall_display_light
+          rgb_color: [0, 0, 255]
+
+group:
+  bus_times:
+    name: Bus Times
+    icon: mdi:bus
+    entities:
+      - sensor.busses_at_stop
+      - sensor.bus_1_time
+      - sensor.bus_1_route
+      - sensor.bus_2_time
+      - sensor.bus_2_route
+      - input_boolean.bus_alert
+      - input_boolean.bus_alert_active # Debug
+      # - automation.set_display_led_based_on_bus_time__1
+      # - automation.set_display_led_based_on_bus_time__2
+      # - automation.set_display_led_based_on_bus_time__3
+      - light.wall_display_light
+      - light.wall_display_screen
+      - automation.turn_on_the_wall_display_when_corban_gets_home
+
+homeassistant:
+  customize:
+    sensor.busses_at_stop:
+      friendly_name: Next Bus
+      icon: mdi:bus-clock
+    sensor.bus_1_time:
+      icon: mdi:bus-clock
+    sensor.bus_2_time:
+      icon: mdi:bus-clock
+    sensor.bus_1_route:
+      icon: mdi:bus-side
+    sensor.bus_2_route:
+      icon: mdi:bus-side
+    light.wall_display_light:
+      icon: mdi:tablet
+    light.wall_display_screen:
+      icon: mdi:monitor

--- a/script/obama_management.yaml
+++ b/script/obama_management.yaml
@@ -2,11 +2,10 @@
 
 shutdown_obama:
   sequence:
-    # - service: media_player.kodi_call_method
-    #   data:
-    #     entity_id: media_player.kodi_obama
-    #     method: System.Shutdown
-    - service: shell_command.shutdown_obama
+    - service: hassio.addon_stdin
+      data:
+        addon: core_rpc_shutdown
+        input: obama
 
 kodi_update_video:
   sequence:

--- a/sensor/weather.yaml
+++ b/sensor/weather.yaml
@@ -15,9 +15,13 @@
 
 - platform: darksky
   api_key: !secret darksky_api_key
+  update_interval:
+    minutes: 5
+  forecast:
+    - 1
   monitored_conditions:
     - summary
-    # - icon
+    - icon
     - precip_type
     - precip_intensity
     - precip_intensity_max
@@ -29,13 +33,13 @@
     - apparent_temperature_max
     - apparent_temperature_min
     # - dew_point
-    # - wind_speed
-    # - wind_bearing
+    - wind_speed
+    - wind_bearing
     - cloud_cover
     - humidity
-    # - pressure
+    - pressure
     # - visibility
     # - ozone
     - minutely_summary
     - hourly_summary
-    # - daily_summary
+    #- daily_summary

--- a/shell_command/obama_management.yaml
+++ b/shell_command/obama_management.yaml
@@ -1,3 +1,0 @@
-# Obama Management Shell Commands
-
-shutdown_obama: !secret obama_shell_command_shutdown

--- a/switch/mqtt.yaml
+++ b/switch/mqtt.yaml
@@ -3,45 +3,60 @@
 # Power Tails
 - platform: mqtt
   name: strobe_light # christmas_lights # power_tail_1
-  state_topic: "home/sonoff/power_tail/1/stat"
-  command_topic: "home/sonoff/power_tail/1"
+  state_topic: "stat/sonoff_1/POWER"
+  command_topic: "cmnd/sonoff_1/POWER"
+  availability_topic: "tele/sonoff_1/LWT"
   qos: 1
-  payload_on: "on"
-  payload_off: "off"
+  payload_on: "ON"
+  payload_off: "OFF"
+  payload_available: "Online"
+  payload_not_available: "Offline"
   retain: true
 
 - platform: mqtt
   name: living_room_lamp_near_tv # power_tail_2
-  state_topic: "home/sonoff/power_tail/2/stat"
-  command_topic: "home/sonoff/power_tail/2"
+  state_topic: "stat/sonoff_2/POWER"
+  command_topic: "cmnd/sonoff_2/POWER"
+  availability_topic: "tele/sonoff_2/LWT"
   qos: 1
-  payload_on: "on"
-  payload_off: "off"
+  payload_on: "ON"
+  payload_off: "OFF"
+  payload_available: "Online"
+  payload_not_available: "Offline"
   retain: true
 
 - platform: mqtt
   name: living_room_corner # power_tail_3
-  state_topic: "home/sonoff/power_tail/3/stat"
-  command_topic: "home/sonoff/power_tail/3"
+  state_topic: "stat/sonoff_3/POWER"
+  command_topic: "cmnd/sonoff_3/POWER"
+  availability_topic: "tele/sonoff_3/LWT"
   qos: 1
-  payload_on: "on"
-  payload_off: "off"
+  payload_on: "ON"
+  payload_off: "OFF"
+  payload_available: "Online"
+  payload_not_available: "Offline"
   retain: true
 
 - platform: mqtt
   name: living_room_window # power_tail_4
-  state_topic: "home/sonoff/power_tail/4/stat"
-  command_topic: "home/sonoff/power_tail/4"
+  state_topic: "stat/sonoff_4/POWER"
+  command_topic: "cmnd/sonoff_4/POWER"
+  availability_topic: "tele/sonoff_4/LWT"
   qos: 1
-  payload_on: "on"
-  payload_off: "off"
+  payload_on: "ON"
+  payload_off: "OFF"
+  payload_available: "Online"
+  payload_not_available: "Offline"
   retain: true
 
 - platform: mqtt
   name: living_room_couch # power_tail_5
-  state_topic: "home/sonoff/power_tail/5/stat"
-  command_topic: "home/sonoff/power_tail/5"
+  state_topic: "stat/sonoff_5/POWER"
+  command_topic: "cmnd/sonoff_5/POWER"
+  availability_topic: "tele/sonoff_5/LWT"
   qos: 1
-  payload_on: "on"
-  payload_off: "off"
+  payload_on: "ON"
+  payload_off: "OFF"
+  payload_available: "Online"
+  payload_not_available: "Offline"
   retain: true

--- a/zone/cht.yaml
+++ b/zone/cht.yaml
@@ -1,0 +1,5 @@
+- name: CHT
+  latitude: !secret cht_latitude
+  longitude: !secret cht_longitude
+  radius: 100
+  icon: mdi:laptop

--- a/zone/re.yaml
+++ b/zone/re.yaml
@@ -1,0 +1,5 @@
+- name: RE
+  latitude: !secret re_latitude
+  longitude: !secret re_longitude
+  radius: 600
+  icon: mdi:flask-outline


### PR DESCRIPTION
The git version of my configuration has fallen behind, so this is the catchup. Since the last push, I've done the following:
* Moved to HassIO (from Hassbian), so my style of configuration has changed a bit.
* Added AppDaemon/HADashboard.
  * I'm still experimenting with this, but I think it will be great.
* Added a custom component for the new wall-mount display that allows controlling the side RGB LEDs and the screen.
* Added REST sensors for the next bus to arrive near my (new) apartment. 
  * Also some new automations to set the wall display's LEDs based on how many minutes there are until the next bus arrives.
* Migrated all of my Sonoffs to Tasmota firmware.
* Set up the Google Maps device tracker. (Not sure yet, but this is seeming pretty reliable so far.)